### PR TITLE
fix for crash sorting null entries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,9 +59,13 @@ function getEntries(softFail, url) {
 }
 
 function sortEntries(entry) {
-  var date = new Date(entry.pubdate);
-  var time = date.getTime();
-  return time * -1;
+  if (entry) {
+      var date = new Date(entry.pubdate);
+      var time = date.getTime();
+      return time * -1;
+  } else {
+      return null;
+  }
 }
 
 function createFeed(feedConfig, entries) {


### PR DESCRIPTION
When using `softFail: true` sometimes `null` entries are inserted which causes the sorting to crash.

```
An error has occured. error is: TypeError: Cannot read property 'pubdate' of null and stack trace is: TypeError: Cannot read property 'pubdate' of null
    at sortEntries (/node_modules/rss-combiner/lib/index.js:67:28)
    at /node_modules/lodash/lodash.js:3738:18
    at arrayMap (/node_modules/lodash/lodash.js:660:23)
    at /node_modules/lodash/lodash.js:3737:24
    at /node_modules/lodash/lodash.js:3554:27
    at /node_modules/lodash/lodash.js:4920:15
    at baseMap (/node_modules/lodash/lodash.js:3553:7)
    at baseOrderBy (/node_modules/lodash/lodash.js:3736:20)
    at Function.<anonymous> (/node_modules/lodash/lodash.js:9956:14)
    at apply (/node_modules/lodash/lodash.js:496:27)
```

Better to not insert `null`s into the result set but here's a quick workaround.
